### PR TITLE
Remove redundant RequestException re-throwing and improve Pantry text…

### DIFF
--- a/src/Basket.php
+++ b/src/Basket.php
@@ -70,13 +70,8 @@ class Basket extends Client
      */
     public function update(array $data): void
     {
-        try {
-
-            $this->request("PUT", "/basket/$this->name", $data);
-            $this->data = (object)$data;
-        } catch (\GuzzleHttp\Exception\ClientException $e) {
-            throw new RequestException("An error occurred while updating the basket.", 0, $e);
-        }
+        $this->request("PUT", "/basket/$this->name", $data);
+        $this->data = (object)$data;
     }
 
     /**
@@ -86,11 +81,6 @@ class Basket extends Client
      */
     public function delete(): object
     {
-        try {
-
-            return $this->request("DELETE", "/basket/$this->name");
-        } catch (\GuzzleHttp\Exception\ClientException $e) {
-            throw new RequestException("An error occurred while deleting the basket.", 0, $e);
-        }
+        return $this->request("DELETE", "/basket/$this->name");
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -63,11 +63,8 @@ class Client
         } catch (ClientException $e) {
             throw new RequestException($e->getMessage(), $e->getResponse()->getStatusCode(), 0, $e);
         }
-        try {
-            return json_decode($data);
-        } catch (TypeError $e) { // text responses
-            return (object)["response" => $data];
-        }
+        $output = json_decode($data);
+        return $output === null ? (object)["response" => $data] : $output;
     }
 
     /**
@@ -132,11 +129,7 @@ class Client
      */
     public function update(array $data): void
     {
-        try {
-            $this->request("PUT", "", $data);
-        } catch (ClientException $e) {
-            throw new RequestException("An error occurred while updating the pantry.", $e->getResponse()->getStatusCode(), 0, $e);
-        }
+       $this->request("PUT", "", $data);
     }
 
     /**
@@ -154,13 +147,13 @@ class Client
         try {
             $response = $this->request("GET", "/basket/$name");
             return new Basket($this->pantryID, $name, $response);
-        } catch (ClientException $e) {
+        } catch (RequestException $e) {
 
-            if ($e->getResponse()->getStatusCode() === 400) {
+            if ($e->getHttpCode() === 400) {
                 throw new BasketNotFoundException("Basket '$name' not found.", 400, $e);
             }
 
-            throw new RequestException("An error occurred while fetching the basket.", $e->getResponse()->getStatusCode(), 0, $e);
+            throw $e;
         }
     }
 
@@ -176,11 +169,7 @@ class Client
      */
     public function createBasket(string $name, array $contents): Basket
     {
-        try {
-            $this->request("POST", "/basket/$name", $contents);
-            return new Basket($this->pantryID, $name, (object)$contents);
-        } catch (ClientException $e) {
-            throw new RequestException("An error occurred while creating the basket.", $e->getResponse()->getStatusCode(), 0, $e);
-        }
+        $this->request("POST", "/basket/$name", $contents);
+        return new Basket($this->pantryID, $name, (object)$contents);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,7 +5,6 @@ namespace Pantry;
 use GuzzleHttp\Exception\ClientException;
 use Pantry\Exceptions\BasketNotFoundException;
 use Pantry\Exceptions\RequestException;
-use TypeError;
 
 class Client
 {
@@ -61,10 +60,10 @@ class Client
             $res = $this->async ? $this->HttpClient->sendAsync($request)->wait() : $this->HttpClient->send($request);
             $data = $res->getBody()->getContents();
         } catch (ClientException $e) {
-            throw new RequestException($e->getMessage(), $e->getResponse()->getStatusCode(), 0, $e);
+            throw new RequestException($e->getMessage(), $e->getResponse()->getStatusCode(), 0);
         }
-        $output = json_decode($data);
-        return $output === null ? (object)["response" => $data] : $output;
+
+        return json_decode($data) ?? (object)["response" => $data];
     }
 
     /**
@@ -129,7 +128,7 @@ class Client
      */
     public function update(array $data): void
     {
-       $this->request("PUT", "", $data);
+        $this->request("PUT", "", $data);
     }
 
     /**
@@ -150,7 +149,7 @@ class Client
         } catch (RequestException $e) {
 
             if ($e->getHttpCode() === 400) {
-                throw new BasketNotFoundException("Basket '$name' not found.", 400, $e);
+                throw new BasketNotFoundException("Basket '$name' not found.", 400);
             }
 
             throw $e;
@@ -158,7 +157,7 @@ class Client
     }
 
     /**
-     * Creates a new basket.
+     * Creates a new basket or replaces an existing one.
      *
      * @param string $name               The name of the basket.
      * @param array $contents            The basket contents.


### PR DESCRIPTION
After seeing the new code from #5 and #6, I realized there were some minor issues that needed to be addressed. First, the original fix from #5 re-throws errors as a custom `RequestException` type instead of the Guzzle exception type; this would be fine, except for the fact that everything *catching* `request()` was still listening for `ClientException`, which would obviously be never thrown. 
Additionally, the current logic (since #6) for detecting invalid JSON was based on the action of returning `null` throwing an error, which isn't exactly the most reliable way to detect if it failed.
Let me know what you think!